### PR TITLE
Update text on Version Independence

### DIFF
--- a/draft-ietf-quic-load-balancers.md
+++ b/draft-ietf-quic-load-balancers.md
@@ -879,10 +879,10 @@ trips in the connection.
 UDP port, client-generated destination Connection ID) remain constant for all
 packets sent on the same connection.
 
-While this document does not update the
-commitments in {{QUIC-INVARIANTS}}, the additional assumptions are minimal and
-narrowly scoped, and provide a likely set of constants that load balancers can
-use with minimal risk of version-dependence.
+While this document does not update the commitments in {{QUIC-INVARIANTS}}, the
+additional assumptions are minimal and narrowly scoped, and provide a likely
+set of constants that load balancers can use with minimal risk of version-
+dependence.
 
 If these assumptions are invalid, this specification is likely to lead to loss
 of packets that contain non-compliant DCIDs, and in extreme cases connection

--- a/draft-ietf-quic-load-balancers.md
+++ b/draft-ietf-quic-load-balancers.md
@@ -877,7 +877,9 @@ handle these DCIDs, rests on some assumptions:
 trips in the connection.
 * While the client is using DCIDs it generated, some exposed fields (IP address,
 UDP port, client-generated destination Connection ID) remain constant for all
-packets sent on the same connection. While this document does not update the
+packets sent on the same connection.
+
+While this document does not update the
 commitments in {{QUIC-INVARIANTS}}, the additional assumptions are minimal and
 narrowly scoped, and provide a likely set of constants that load balancers can
 use with minimal risk of version-dependence.
@@ -1147,4 +1149,3 @@ cid:  93256308e3d349f8839dec840b0a90c7e7a1fc20 sid: 618b07791f
 
 - Converted to markdown
 - Added variable length connection IDs
-

--- a/draft-ietf-quic-load-balancers.md
+++ b/draft-ietf-quic-load-balancers.md
@@ -261,11 +261,11 @@ to an active server using an algorithm of its own choosing. It need not
 coordinate this algorithm with the servers. The algorithm SHOULD be
 deterministic over short time scales so that related packets go to the same
 server. The design of this algorithm SHOULD consider the version-invariant
-properties of QUIC described in {{QUIC-INVARIANTS}} to maximize its robustness to
-future versions of QUIC. For example, a non-compliant DCID might be converted to
-an integer and divided by the number of servers, with the modulus used to forward
-the packet. The number of servers is usually consistent on the time scale of a
-QUIC connection handshake.
+properties of QUIC described in {{QUIC-INVARIANTS}} to maximize its robustness
+to future versions of QUIC. For example, a non-compliant DCID might be converted
+to an integer and divided by the number of servers, with the modulus used to
+forward the packet. The number of servers is usually consistent on the time
+scale of a QUIC connection handshake. See also {{version-invariance}}.
 
 Load balancers SHOULD drop packets with non-compliant DCIDs in a short header.
 
@@ -853,7 +853,7 @@ with the new server using the "Retire Prior To" field in that frame.
 Alternately, if the old server is going offline, the load balancer could simply
 map its server ID to the new server's address.
 
-# Version Invariance of QUIC-LB
+# Version Invariance of QUIC-LB {#version-invariance}
 
 Retry Services are inherently dependent on the format (and existence) of Retry
 Packets in each version of QUIC, and so Retry Service configuration explicitly
@@ -875,12 +875,12 @@ handle these DCIDs, rests on some assumptions:
 * Incoming short headers do not contain DCIDs that are client-generated.
 * The use of client-generated incoming DCIDs does not persist beyond a few round
 trips in the connection.
-* In this interval, some exposed fields (e.g. UDP address and port, client-
-generated destination Connection ID) remain constant for all packets in the
-connection. For example, 0RTT and Initial packets use the same DCIDs and ports.
-While this document does not update the commitments in {{QUIC-INVARIANTS}}, the
-authors believe that the listed examples are a likely set of constants that load
-balancers can use with minimal risk of version-dependence.
+* While the client is using DCIDs it generated, some exposed fields (IP address,
+UDP port, client-generated destination Connection ID) remain constant for all
+packets sent on the same connection. While this document does not update the
+commitments in {{QUIC-INVARIANTS}}, the authors believe that the listed examples
+are a likely set of constants that load balancers can use with minimal risk of
+version-dependence.
 
 If these assumptions are invalid, this specification is likely to lead to loss
 of packets that contain non-compliant DCIDs, and in extreme cases connection

--- a/draft-ietf-quic-load-balancers.md
+++ b/draft-ietf-quic-load-balancers.md
@@ -878,9 +878,9 @@ trips in the connection.
 * While the client is using DCIDs it generated, some exposed fields (IP address,
 UDP port, client-generated destination Connection ID) remain constant for all
 packets sent on the same connection. While this document does not update the
-commitments in {{QUIC-INVARIANTS}}, the authors believe that the listed examples
-are a likely set of constants that load balancers can use with minimal risk of
-version-dependence.
+commitments in {{QUIC-INVARIANTS}}, the additional assumptions are minimal and
+narrowly scoped, and provide a likely set of constants that load balancers can
+use with minimal risk of version-dependence.
 
 If these assumptions are invalid, this specification is likely to lead to loss
 of packets that contain non-compliant DCIDs, and in extreme cases connection

--- a/draft-ietf-quic-load-balancers.md
+++ b/draft-ietf-quic-load-balancers.md
@@ -874,10 +874,12 @@ handle these DCIDs, rests on some assumptions:
 * Incoming short headers do not contain DCIDs that are client-generated.
 * The use of client-generated incoming DCIDs does not persist beyond a few round
 trips in the connection.
-* In this interval, some exposed fields (e.g. UDP address and port, source and
-client-generated destination Connection ID) remain constant for all packets in
-the connection. For example, 0RTT and Initial packets use the same CIDs and
-ports.
+* In this interval, some exposed fields (e.g. UDP address and port, client-
+generated destination Connection ID) remain constant for all packets in the
+connection. For example, 0RTT and Initial packets use the same DCIDs and ports.
+While this document does not update the commitments in {{QUIC-INVARIANTS}}, the
+authors believe that the listed examples are a likely set of constants that load
+balancers can use with minimal risk of version-dependence.
 
 If these assumptions are invalid, this specification is likely to lead to loss
 of packets that contain non-compliant DCIDs, and in extreme cases connection


### PR DESCRIPTION
Carefully phrased language that considers @martinthomson 's suggestion that SCID may not be stable across versions, and tries to suggest (IP, port, DCID) as a suitable long header hash without making promises on behalf of quic-invariants.

Fixes #22.