### PR TITLE
Try to diagram the Nonce length

### DIFF
--- a/draft-ietf-quic-load-balancers.md
+++ b/draft-ietf-quic-load-balancers.md
@@ -378,7 +378,7 @@ All connection IDs use the following format:
 ~~~
 QUIC-LB Connection ID {
     First Octet (8),
-    Server ID (..152-len(Nonce)),
+    Server ID (8..152-len(Nonce)),
     Nonce (32..152-len(Server ID),
 }
 ~~~


### PR DESCRIPTION
Since you say Nonce must be at least 4 bytes, I started there (`32..`). Then I saw your novel new `len` notation and thought I'd try it out. No idea if this is how you intended it to be used though because the only thing that uses it is an example!