### PR TITLE
Key lookup problems aren't guaranteed

### DIFF
--- a/draft-ietf-quic-load-balancers.md
+++ b/draft-ietf-quic-load-balancers.md
@@ -214,9 +214,9 @@ ID from short headers.
 
 Local hardware cryptographic offload devices may accelerate QUIC servers by
 receiving keys from the QUIC implementation indexed to the connection ID.
-However, on physical devices operating multiple QUIC servers, it is impractical
-to efficiently lookup these keys if the connection ID does not self-encode its
-own length.
+However, on physical devices operating multiple QUIC servers, it might be
+impractical to efficiently lookup keys if the connection ID varies in length and
+does not self-encode its own length.
 
 Note that this is a function of particular server devices and is irrelevant to
 load balancers. As such, load balancers MAY omit this from their configuration.

--- a/draft-ietf-quic-load-balancers.md
+++ b/draft-ietf-quic-load-balancers.md
@@ -343,7 +343,7 @@ addresses. The corresponding server configurations contain one or
 more unique server IDs.
 
 The configuration agent chooses a server ID length for each configuration that
-MUST be at least one octet. 
+MUST be at least one octet.
 
 A QUIC-LB configuration MAY significantly over-provision the server ID space
 (i.e., provide far more codepoints than there are servers) to increase the
@@ -432,7 +432,7 @@ the second through seventeenth most significant bytes of the connection ID.
 ### General Case: Four-Pass Encryption
 
 Any other field length requires four passes for encryption and at least three
-for decryption. To understand this algorithm, it is useful to define four 
+for decryption. To understand this algorithm, it is useful to define four
 functions that minimize the amount of bit-shifting necessary in the event that
 there are an odd number of octets.
 


### PR DESCRIPTION
This only applies if the CID varies in length (so say that).

Also, it only applies if the common stem doesn't otherwise distinguish itself enough to allow an efficient lookup (so say "might" rather than get into all that).

In other words, it's probably inefficient, but not necessarily so.