### PR TITLE
No understandy = no worky

### DIFF
--- a/draft-ietf-quic-load-balancers.md
+++ b/draft-ietf-quic-load-balancers.md
@@ -747,16 +747,19 @@ dependence.
 
 If these assumptions are not valid, this specification is likely to lead to loss
 of packets that contain unroutable DCIDs, and in extreme cases connection
-failure.
+failure.  A QUIC version that violates the assumptions in this section therefore
+cannot be safely deployed with a load balancer that follows this specification.
+An updated or alternative version of this specification might address these
+shortcomings for such a QUIC version.
 
-Some load balancers might inspect elements of the Server Name Indication (SNI)
-extension in the TLS Client Hello to make a routing decision. Note that the
-format and cryptographic protection of this information may change in future
-versions or extensions of TLS or QUIC, and therefore this functionality is
-inherently not version-invariant. See also {{unroutable}} for other
-considerations about this case. Note that an SNI-aware load balancer, faced with
-an unknown QUIC version, might misdirect initial packets to the wrong tenant.
-While inefficient, this preserves the ability for tenants to deploy new versions
+Some load balancers might inspect version-specific elements of packets to make a
+routing decision.  This might include the Server Name Indication (SNI) extension
+in the TLS Client Hello.  The format and cryptographic protection of this
+information may change in future versions or extensions of TLS or QUIC, and
+therefore this functionality is inherently not version-invariant. Such a load
+balancer, when it receives packets from an unknown QUIC version, might misdirect
+initial packets to the wrong tenant.  While this can be inefficient, the design
+in this document preserves the ability for tenants to deploy new versions
 provided they have an out-of-band means of providing a connection ID for the
 client to use.
 

--- a/draft-ietf-quic-load-balancers.md
+++ b/draft-ietf-quic-load-balancers.md
@@ -343,7 +343,7 @@ addresses. The corresponding server configurations contain one or
 more unique server IDs.
 
 The configuration agent chooses a server ID length for each configuration that
-MUST be at least one octet. 
+MUST be at least one octet.
 
 A QUIC-LB configuration MAY significantly over-provision the server ID space
 (i.e., provide far more codepoints than there are servers) to increase the
@@ -432,7 +432,7 @@ the second through seventeenth most significant bytes of the connection ID.
 ### General Case: Four-Pass Encryption
 
 Any other field length requires four passes for encryption and at least three
-for decryption. To understand this algorithm, it is useful to define four 
+for decryption. To understand this algorithm, it is useful to define four
 functions that minimize the amount of bit-shifting necessary in the event that
 there are an odd number of octets.
 


### PR DESCRIPTION
THe addition to the first paragraph here seems necessary.  The basic
idea is that if a QUIC version violates the (reasonable) assumptions
this section makes, then it just doesn't work if you try to apply this
design.  You will need to update your load balancer and probably update
the CID allocation/negotiation/configuration you are using.

The second paragraph I'm less sure about.  I think that the intent was
to say that if you follow the advice here you still get a functioning
system even if the load balancer gets it wrong.  So I said that.  I
think that I agree, provided that the tenant (new term?) chooses a good
connection ID for any new ones.  So that's not just Section 3.1 you need
to refer to, but the whole document.