### PR TITLE
Bump the aasvg dependency to get the XOR fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "aasvg": "^0.3.2"
+    "aasvg": "^0.3.3"
   }
 }


### PR DESCRIPTION
It's possible that the version on gh-pages is stuck because I cache dependencies.  That's ordinarily good, but when you need a bugfix...