### PR TITLE
Delete text on dropping packets

### DIFF
--- a/draft-ietf-quic-load-balancers.md
+++ b/draft-ietf-quic-load-balancers.md
@@ -394,39 +394,6 @@ load balancer will misroute packets.
 Load balancers SHOULD maintain per-flow timers to periodically purge state in
 the tables described above.
 
-## Dropping packets
-
-Some unroutable connection IDs are evidently client-generated if all servers
-behind the load balancer are compliant with this specification. In particular,
-an unroutable CID is evidently client-generated if
-- it does not use the 0b111 config ID; OR
-- it uses the 0b111 config ID, it is in a long header packet, and its self-
-encoded length does not match the length in the long header field.
-- the server is self-encoding CID length, but the length is not consistent with
-the config ID.
-
-When load balancers are guaranteed to have a superset of all server
-configurations, but servers might have no configuration at all, all valid QUIC
-short headers have either a routable DCID or use config ID 0b111. Under these
-conditions, load balancers MAY drop packets with short headers and unroutable
-DCIDs that do not have config ID 0b111.
-
-Load balancers MAY drop packets with evidently client-generated DCIDs if and
-only if it knows that the encoded QUIC version only allows the sending of that
-signature after the server has the opportunity to update the connection ID.
-For example, a load balancer can safely drop a QUIC version 1 Handshake packet
-with a client-generated DCID, as a version 1 Handshake packet sent to a QUIC-LB
-routable server will always have a server-generated CID. Load balancers MUST NOT
-drop packets with long headers and unknown QUIC versions.
-
-Under all other circumstances, load balancers MUST NOT drop packets with
-unroutable DCIDs, and instead forward it using the procedure above.
-
-While the load balancer function on a device has restrictions on which packets
-it can drop, a colocated function, outside the scope of this specification, can
-apply other policies to drop packets. For example, a rate limiting or security
-function might drop packets that the load balancer routes.
-
 # Server ID Encoding in Connection IDs
 
 ## Server ID Allocation {#sid-allocation}


### PR DESCRIPTION
Fixes #238 

Basically, all this text does nothing to mitigate DoS attacks and is really complex and conditional.